### PR TITLE
04-data-types-and-format.md "Names" -> "Name"

### DIFF
--- a/_episodes/04-data-types-and-format.md
+++ b/_episodes/04-data-types-and-format.md
@@ -321,7 +321,7 @@ This is a convenient place to highlight that the `apply` method is one way to ru
 the Buoy Station Names, we can write:
 
 ~~~
-waves_df["Names"].apply(len)
+waves_df["Name"].apply(len)
 ~~~
 {: .language-python}
 


### PR DESCRIPTION
The `.apply(len)` example in our fork of this lesson calculates the length of the name string, but the column is called name, not names. This is a one-character fix for this
